### PR TITLE
Update DocRaptor casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# PHP Docrapter API
+# PHP DocRapter API
 
-A simple client for the Docraptor API, written in PHP5.
+A simple client for the [DocRaptor](https://docraptor.com) API, written in PHP5.
 
 ## Features
 
-* Convert PDF documents through the Docraptor API.
+* Convert HTML to PDF and HTML to Excel through the DocRaptor API.
 
 ## Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bytes/docraptor",
     "type": "library",
-    "description": "Docraptor API client",
+    "description": "DocRaptor API client",
     "keywords": ["docraptor", "api"],
     "homepage": "http://github.com/MartijnDwars/Docraptor",
     "license": "MIT",

--- a/src/Bytes/Docraptor/Client.php
+++ b/src/Bytes/Docraptor/Client.php
@@ -6,7 +6,7 @@ use Bytes\Docraptor\Http\ClientInterface as HttpClientInterface;
 use Bytes\Docraptor\Document\DocumentInterface;
 
 /**
- * Docraptor client
+ * DocRaptor client
  */
 class Client implements ClientInterface
 {
@@ -18,7 +18,7 @@ class Client implements ClientInterface
     private $_httpClient;
 
     /**
-     * Docraptor API key
+     * DocRaptor API key
      *
      * @var string
      */
@@ -60,7 +60,7 @@ class Client implements ClientInterface
             ->setBaseUrl('https://docraptor.com')
             ->setDefaultHeaders(array(
                 'Authorization' => 'Basic '.base64_encode($apiKey.':'),
-                'User-Agent' => 'Bytes Docraptor client',
+                'User-Agent' => 'Bytes DocRaptor client',
             ))
         ;
     }
@@ -91,7 +91,7 @@ class Client implements ClientInterface
     /**
      * Set API key
      *
-     * @param string $apiKey Docraptor API key
+     * @param string $apiKey DocRaptor API key
      * @return Client
      */
     public function setApiKey($apiKey)
@@ -197,7 +197,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * Convert document using docraptor API
+     * Convert document using DocRaptor API
      *
      * @param DocumentInterface $document The document to be converted
      * @return string The binary contents of the result after conversion

--- a/src/Bytes/Docraptor/Exception/UnexpectedValueException.php
+++ b/src/Bytes/Docraptor/Exception/UnexpectedValueException.php
@@ -6,6 +6,6 @@ class UnexpectedValueException extends \UnexpectedValueException implements Docr
 {
     public function __construct($code = 0)
     {
-        parent::__construct('Docraptor returned an unexpected response ('.$code.')', $code);
+        parent::__construct('DocRaptor returned an unexpected response ('.$code.')', $code);
     }
 }

--- a/src/Bytes/Docraptor/Exception/UnprocessableEntityException.php
+++ b/src/Bytes/Docraptor/Exception/UnprocessableEntityException.php
@@ -6,6 +6,6 @@ class UnprocessableEntityException extends RuntimeException
 {
     public function __construct()
     {
-        parent::__construct('Your document contains syntax errors and Docraptor cannot process it.', 433);
+        parent::__construct('Your document contains syntax errors and DocRaptor cannot process it.', 433);
     }
 }


### PR DESCRIPTION
Update language where appropriate for the proper casing of DocRaptor and add link to DocRaptor.

I should say the reasoning for the casing is because otherwise it can be read as DoCraptor. :smile_cat: 

I should also say this repo was an inspiration for a lot of the things we did in https://github.com/expectedbehavior/php-docraptor/, so much appreciation.